### PR TITLE
Fixed DMing users with the new Conversations API

### DIFF
--- a/lib/slacks/connection.rb
+++ b/lib/slacks/connection.rb
@@ -249,7 +249,7 @@ module Slacks
 
     def get_dm_for_user_id(user_id)
       user_ids_dm_ids[user_id] ||= begin
-        response = api("conversations.open", user: user_id)
+        response = api("conversations.open", users: user_id)
         response["channel"]["id"]
       end
     end

--- a/lib/slacks/version.rb
+++ b/lib/slacks/version.rb
@@ -1,3 +1,3 @@
 module Slacks
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end


### PR DESCRIPTION
### Summary
It was `users` instead of `user` 🤦 