### PR TITLE
Missing Groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+### v0.6.2
+- Fixed a regression where groups, DMs, and private channels were not fetched
+
+### v0.6.1
+- Fixed a typo with creating a DM associated with a user
+
+### v0.6.0
+- Switched to using the Slack Conversations API

--- a/lib/slacks/connection.rb
+++ b/lib/slacks/connection.rb
@@ -176,16 +176,27 @@ module Slacks
           "is_im" => true,
           "name" => user.username }
       else
-        Slacks::Channel.new(self, conversations_by_id.fetch(id) do
+        Slacks::Channel.new(self, find_conversation(id))
+      end
+    end
+
+    def find_conversation(id)
+      conversations_by_id.fetch(id) do
+        fetch_conversations!
+        conversations_by_id.fetch(id) do
           raise ArgumentError, "Unable to find a conversation with the ID #{id.inspect}"
-        end)
+        end
       end
     end
 
     def find_user(id)
-      Slacks::User.new(self, users_by_id.fetch(id) do
-        raise ArgumentError, "Unable to find a user with the ID #{id.inspect}"
-      end)
+      user = users_by_id.fetch(id) do
+        fetch_users!
+        users_by_id.fetch(id) do
+          raise ArgumentError, "Unable to find a user with the ID #{id.inspect}"
+        end
+      end
+      Slacks::User.new(self, user)
     end
 
     def find_user_by_nickname(nickname)

--- a/lib/slacks/connection.rb
+++ b/lib/slacks/connection.rb
@@ -267,7 +267,7 @@ module Slacks
 
 
     def fetch_conversations!
-      conversations, ims = api("conversations.list")["channels"].partition { |attrs| attrs["is_channel"] || attrs["is_group"] }
+      conversations, ims = api("conversations.list", types: "public_channel,private_channel,mpim,im")["channels"].partition { |attrs| attrs["is_channel"] || attrs["is_group"] }
       user_ids_dm_ids.merge! Hash[ims.map { |attrs| attrs.values_at("user", "id") }]
       @conversations_by_id = Hash[conversations.map { |attrs| [ attrs.fetch("id"), attrs ] }]
       @conversation_ids_by_name = Hash[conversations.map { |attrs| [ attrs["name"], attrs["id"] ] }]

--- a/lib/slacks/version.rb
+++ b/lib/slacks/version.rb
@@ -1,3 +1,3 @@
 module Slacks
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end


### PR DESCRIPTION
### Summary
By default, it turns out `conversations.list` only returns public channels. In order to list all conversation types (per the previous behavior of hitting the various endpoints), the `types:` parameter needed to be supplied.

Also addresses an issue where a channel could be sought out before a fetch had been completed.

Also added a CHANGELOG.