### PR TITLE
Removed dependence on faraday-raise-errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-### v0.6.2
+### v0.6.4
+- Removed reliance on faraday-raise-errors in favor of using built-in Faraday::RaiseError middleware
+
+### v0.6.3
 - Removed remaining calls to `.present?`, since we're not actually dependent on ActiveSupport
 
 ### v0.6.2

--- a/lib/slacks/connection.rb
+++ b/lib/slacks/connection.rb
@@ -7,7 +7,6 @@ require "slacks/guest_channel"
 require "slacks/team"
 require "slacks/user"
 require "faraday"
-require "faraday/raise_errors"
 
 module Slacks
   class Connection
@@ -344,7 +343,7 @@ module Slacks
 
     def http
       @http ||= Faraday.new(url: "https://slack.com/api").tap do |connection|
-        connection.use Faraday::RaiseErrors
+        connection.response :raise_error
       end
     end
 

--- a/lib/slacks/version.rb
+++ b/lib/slacks/version.rb
@@ -1,3 +1,3 @@
 module Slacks
-  VERSION = "0.6.3"
+  VERSION = "0.6.4"
 end

--- a/slacks.gemspec
+++ b/slacks.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "websocket-driver"
   spec.add_dependency "multi_json"
   spec.add_dependency "faraday"
-  spec.add_dependency "faraday-raise-errors"
   spec.add_dependency "concurrent-ruby"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
### Summary
`Faraday::RaiseError` has expanded what errors it raises and is a tidy, Faraday-1.x-compliant way of raising errors for error statuses.